### PR TITLE
feat: 대시보드 주요 지수 현황 조회

### DIFF
--- a/src/main/java/com/sprint/project/findex/controller/IndexDataController.java
+++ b/src/main/java/com/sprint/project/findex/controller/IndexDataController.java
@@ -1,0 +1,28 @@
+package com.sprint.project.findex.controller;
+
+import com.sprint.project.findex.dto.dashboard.IndexPerformanceDto;
+import com.sprint.project.findex.service.DashboardService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(("/index-data"))
+public class IndexDataController {
+
+  private final DashboardService dashboardService;
+
+  @GetMapping(value = "/performance/favorite")
+  public ResponseEntity getIndexPerformance(
+      @RequestParam("periodType") String periodType
+  ) {
+    List<IndexPerformanceDto> dto = dashboardService.findFavoriteIndexPerformance(periodType);
+
+    return ResponseEntity.ok(dto);
+  }
+}

--- a/src/main/java/com/sprint/project/findex/dto/dashboard/DashboardQueryDto.java
+++ b/src/main/java/com/sprint/project/findex/dto/dashboard/DashboardQueryDto.java
@@ -1,0 +1,11 @@
+package com.sprint.project.findex.dto.dashboard;
+
+public record DashboardQueryDto(
+
+    Long indexInfoId,
+    String indexClassification,
+    String indexName,
+    Double currentPrice,
+    Double beforePrice
+
+) { }

--- a/src/main/java/com/sprint/project/findex/dto/dashboard/IndexPerformanceDto.java
+++ b/src/main/java/com/sprint/project/findex/dto/dashboard/IndexPerformanceDto.java
@@ -1,0 +1,13 @@
+package com.sprint.project.findex.dto.dashboard;
+
+public record IndexPerformanceDto(
+
+    Long indexInfoId,
+    String indexClassification,
+    String indexName,
+    Double versus,
+    Double fluctuationRate,
+    Double currentPrice,
+    Double beforePrice
+
+) { }

--- a/src/main/java/com/sprint/project/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/sprint/project/findex/repository/DashboardRepository.java
@@ -1,0 +1,55 @@
+package com.sprint.project.findex.repository;
+
+import com.sprint.project.findex.dto.dashboard.DashboardQueryDto;
+import com.sprint.project.findex.entity.IndexData;
+import com.sprint.project.findex.entity.DeletedStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DashboardRepository extends JpaRepository<IndexData, Long> {
+
+  // 쿼리문 안에서 IndexPerformanceDto를 바로 매핑하려니 계산하는 과정에서 타입 추론 오류발생
+  // DashboardQueryDto로 우회해서 서비스에서 계산후 처리하는 방향으로 결정
+  // 기간 내 변화가 있었던 즐겨찾기 지수 조회
+  // current = 최신 데이터
+  // before = period 시작일 이후 가장 이른 데이터
+  @Query("""
+      select new com.sprint.project.findex.dto.dashboard.DashboardQueryDto(
+          i.id,
+          i.indexClassification,
+          i.indexName,
+          current.closingPrice,
+          before.closingPrice
+      )
+      from IndexInfo i
+      join IndexData current
+        on current.indexInfo.id = i.id
+       and current.isDeleted = :deletedStatus
+       and current.baseDate = (
+           select max(c.baseDate)
+           from IndexData c
+           where c.indexInfo.id = i.id
+             and c.isDeleted = :deletedStatus
+       )
+      join IndexData before
+        on before.indexInfo.id = i.id
+       and before.isDeleted = :deletedStatus
+       and before.baseDate = (
+           select min(b.baseDate)
+           from IndexData b
+           where b.indexInfo.id = i.id
+             and b.baseDate >= :targetDate
+             and b.isDeleted = :deletedStatus
+       )
+      where i.favorite = true
+        and i.isDeleted = :deletedStatus
+        and current.closingPrice <> before.closingPrice
+      """)
+  List<DashboardQueryDto> findChangedFavoriteIndexPerformance(
+      @Param("targetDate") LocalDate targetDate,
+      @Param("deletedStatus") DeletedStatus deletedStatus
+  );
+}

--- a/src/main/java/com/sprint/project/findex/service/DashboardService.java
+++ b/src/main/java/com/sprint/project/findex/service/DashboardService.java
@@ -1,0 +1,53 @@
+package com.sprint.project.findex.service;
+
+import com.sprint.project.findex.entity.DeletedStatus;
+import com.sprint.project.findex.dto.dashboard.IndexPerformanceDto;
+import com.sprint.project.findex.repository.DashboardRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DashboardService {
+
+  private final DashboardRepository dashboardRepository;
+
+  public List<IndexPerformanceDto> findFavoriteIndexPerformance(String periodType) {
+
+    LocalDate targetDate = calculateTargetDate(LocalDate.now(), periodType);
+
+    return dashboardRepository.findChangedFavoriteIndexPerformance(targetDate, DeletedStatus.ACTIVE)
+        .stream()
+        .map(dto -> {
+          double currentPrice = dto.currentPrice();
+          double beforePrice = dto.beforePrice();
+          double versus = currentPrice - beforePrice;
+          double fluctuationRate = versus * 100.0 / beforePrice;
+
+          return new IndexPerformanceDto(
+              dto.indexInfoId(),
+              dto.indexClassification(),
+              dto.indexName(),
+              versus,
+              fluctuationRate,
+              currentPrice,
+              beforePrice
+          );
+        })
+        .toList();
+  }
+
+  private LocalDate calculateTargetDate(LocalDate currentDate, String periodType) {
+
+    return switch (periodType) {
+      case "DAILY" -> currentDate.minusDays(1);
+      case "WEEKLY" -> currentDate.minusWeeks(1);
+      case "MONTHLY" -> currentDate.minusMonths(1);
+      default -> throw new IllegalArgumentException("잘못된 periodType 입니다.");
+    };
+  }
+}


### PR DESCRIPTION
--- 본문 ---
대시보드 주요 지수(즐겨찾기된 지수)의 일간, 주간, 월간 종가를 비교하는 기능을 구현

--- 꼬리말 ---
feat: #2

## 📝 설명

- 사용자가 즐겨찾기한 지수의 성과 정보를 대시보드에서 조회할 수 있도록 한다.
- 대시보드에서는 주요 지수의 최근 종가 및 성과 정보를 확인할 수 있어야 한다.
- 월간, 주간, 일간 설정에 따라 조회 결과가 달라진다.

## 🚀 변경 사항

- 없습니다!

## 🔗 짧은 회고

- 진행하면서 대시보드 조회 기준이 모호하여 요구사항과 프로토타입 페이지를 계속 확인하며 기준을 고민해보느라 시간이 오래걸렸던 것 같습니다ㅠ

> 마지막에 다음과 같이 issue 번호를 적어주세요.
> merge 가 되면 자동으로 issue 가 닫힙니다.
> `feat #2`
