### PR TITLE
feat: 자동 연동 배치 실행 및 실행 주기 설정 외부화

### DIFF
--- a/src/main/java/com/sprint/project/findex/Findex.java
+++ b/src/main/java/com/sprint/project/findex/Findex.java
@@ -2,7 +2,9 @@ package com.sprint.project.findex;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class Findex {
 

--- a/src/main/java/com/sprint/project/findex/scheduler/AutoSyncScheduler.java
+++ b/src/main/java/com/sprint/project/findex/scheduler/AutoSyncScheduler.java
@@ -1,0 +1,32 @@
+package com.sprint.project.findex.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AutoSyncScheduler {
+
+  // Todo: 추후 서비스 계층 구현 완료되면 활성화 될 에정
+  // private final AutoSyncConfigService autoSyncConfigService;
+
+  // application.yml에서 설정한 cron 값을 호출
+  @Scheduled(cron = "${findex.scheduler.auto-sync.cron}")
+  public void executeAutoSync() {
+    log.info("[Batch Start] 자동 연동 배치 실행 시작");
+
+    try {
+      // Todo: 포함 로직 서비스 호출 코드 작성
+      // autoSyncConfigService.syncEnabledIndices();
+
+      log.info("[Batch End] 자동 연동 배치 실행 완료");
+    } catch (Exception e) {
+      log.error("[Batch Error] 자동 연동 배치 실행 중 오류 발생: {}", e.getMessage());
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,11 @@
 spring:
   profiles:
     active: local
+
+# 스케줄러 설정 추가
+findex:
+  scheduler:
+    auto-sync:
+      # 매일 자정 (0초 0시 0분) 실행
+      cron: "0 0 0 * * *"
+      # cron: "*/10 * * * * *"  # 10초마다 실행 (test)


### PR DESCRIPTION
--- 본문 ---
- Spring Scheduler 기반 자동 연동 배치 실행 구조 구현
- AutoSyncScheduler 클래스 생성
- `@Scheduled` 메서드 구현
- 배치 실행 cron 설정을 application.yml로 분리
- 외부 설정값을 통해 Scheduler 실행 주기 주입

--- 꼬리말 ---
close: #8 #10

## 📝 설명

- Spring Scheduler를 사용하여 일정 주기마다 지수 데이터를 자동으로 연동하는 배치 실행 구조를 구현했습니다.
- 배치 실행 주기를 코드에 하드코딩하지 않고 `application.yml` 설정값으로 분리했습니다.
- Scheduler가 외부 설정값의 cron 표현식을 읽어 실행되도록 구성했습니다.

## 🚀 변경 사항

- 없습니다.

## 🔗 짧은 회고

- 초반에 로컬 레포지토리에서 머지를 잘못해서 개인적으로 혼동이 좀 있었습니다..
- 컨플릭트를 겪고 이번 기회에 경험을 쌓았습니다.

close: #8 #10