### PR TITLE
feat: 지수 데이터 삭제

### DIFF
--- a/src/main/java/com/sprint/project/findex/controller/IndexDataController.java
+++ b/src/main/java/com/sprint/project/findex/controller/IndexDataController.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,12 +51,21 @@ public class IndexDataController {
     return ResponseEntity.status(HttpStatus.OK).body(dto);
   }
 
-    @GetMapping(value = "/performance/favorite")
-    public ResponseEntity<List<IndexPerformanceDto>> getIndexPerformance (
-        @RequestParam("periodType") String periodType
-  ){
-      List<IndexPerformanceDto> dto = dashboardService.findFavoriteIndexPerformance(periodType);
-
-      return ResponseEntity.status(HttpStatus.OK).body(dto);
-    }
+  @DeleteMapping("/{id}")
+  @Operation(summary = "지수 데이터 삭제")
+  public ResponseEntity<?> delete(
+      @PathVariable Long id
+  ) {
+    indexDataService.delete(id);
+    return ResponseEntity.noContent().build();
   }
+
+  @GetMapping(value = "/performance/favorite")
+  public ResponseEntity<List<IndexPerformanceDto>> getIndexPerformance(
+      @RequestParam("periodType") String periodType
+  ) {
+    List<IndexPerformanceDto> dto = dashboardService.findFavoriteIndexPerformance(periodType);
+
+    return ResponseEntity.status(HttpStatus.OK).body(dto);
+  }
+}

--- a/src/main/java/com/sprint/project/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/project/findex/repository/IndexDataRepository.java
@@ -4,8 +4,11 @@ import com.sprint.project.findex.entity.DeletedStatus;
 import com.sprint.project.findex.entity.IndexData;
 import com.sprint.project.findex.entity.IndexInfo;
 import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IndexDataRepository extends JpaRepository<IndexData, Long> {
   boolean existsByIndexInfoAndBaseDateAndIsDeleted(IndexInfo indexInfo, LocalDate baseDate, DeletedStatus deletedStatus);
+
+  Optional<IndexData> findByIdAndIsDeleted(Long id, DeletedStatus isDeleted);
 }

--- a/src/main/java/com/sprint/project/findex/service/IndexDataService.java
+++ b/src/main/java/com/sprint/project/findex/service/IndexDataService.java
@@ -26,6 +26,7 @@ public class IndexDataService {
 
   public IndexDataDto createByUser(IndexDataCreateRequest request) {
 
+    //todo 임시로 findById를 호출하고 있음, 추후 Soft Delete 로직 적용 시 달라질 수 있음
     IndexInfo indexInfo = indexInfoRepository.findById(request.indexInfoId())
         .orElseThrow(() -> new NoSuchElementException("지수 정보를 찾을 수 없습니다."));
 
@@ -52,10 +53,8 @@ public class IndexDataService {
     return indexDataMapper.toDto(indexData);
   }
 
-  //todo OPEN API 이용한 자동 등록 (기존 데이터가 없을 때 등록)
-
   public IndexDataDto update(Long id, IndexDataUpdateRequest request) {
-    IndexData indexData = indexDataRepository.findById(id)
+    IndexData indexData = indexDataRepository.findByIdAndIsDeleted(id, DeletedStatus.ACTIVE)
         .orElseThrow(() -> new NoSuchElementException("지수 데이터를 찾을 수 없습니다."));
     indexData.updateMarketPrice(request.marketPrice());
     indexData.updateClosingPrice(request.closingPrice());
@@ -72,7 +71,11 @@ public class IndexDataService {
     return indexDataMapper.toDto(indexData);
   }
 
-  //todo OPEN API 이용한 자동 수정 (기존 데이터가 있다면 데이터 확인 후 수정)
+  public void delete(Long id) {
+    IndexData indexData = indexDataRepository.findByIdAndIsDeleted(id, DeletedStatus.ACTIVE)
+        .orElseThrow(() -> new NoSuchElementException("지수 데이터를 찾을 수 없습니다."));
+    indexData.updateIsDeleted(DeletedStatus.DELETED);
+  }
 
   private void validateDuplicateData(IndexDataCreateRequest request, IndexInfo indexInfo) {
     boolean exists = indexDataRepository.existsByIndexInfoAndBaseDateAndIsDeleted(indexInfo,


### PR DESCRIPTION
## 📝 설명

- IndexDataRepository의 findByIdAndIsDeleted()를 통해 DeletedStatus.ACTIVE인 지수 데이터만 가져올 수 있도록 구현했습니다.
- IndexDataService의 delete(), update() 메서드에 findByIdAndIsDeleted()를 적용했습니다.
- IndexController에 삭제 엔드포인트 작성했습니다.

## 🚀 변경 사항

- indexInfoRepository의 조회 메서드에서 아직 DeletedStatus를 파라미터로 받고 있지 않기 때문에 주석으로 명시해두었습니다.

## 🔗 짧은 회고

- 없습니다.

> 마지막에 다음과 같이 issue 번호를 적어주세요.
> merge 가 되면 자동으로 issue 가 닫힙니다.
> `feat #20`
