### PR TITLE
feat: 자동 연동 대상 지수 필터링 구현

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,0 @@
-# LOCAL 설정
-LOCAL_DB_URL=jdbc:postgresql://localhost:5432/findexdb
-LOCAL_DB_USERNAME=admin
-LOCAL_DB_PASSWORD=admin1234
-
-# PRODUCTION 설정
-PROD_DB_URL=
-PROD_DB_USERNAME=
-PROD_DB_PASSWORD=

--- a/src/main/java/com/sprint/project/findex/entity/AutoSyncConfig.java
+++ b/src/main/java/com/sprint/project/findex/entity/AutoSyncConfig.java
@@ -1,6 +1,5 @@
 package com.sprint.project.findex.entity;
 
-import com.sprint.project.findex.IndexInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/sprint/project/findex/mapper/AutoSyncConfigMapper.java
+++ b/src/main/java/com/sprint/project/findex/mapper/AutoSyncConfigMapper.java
@@ -10,6 +10,6 @@ public interface AutoSyncConfigMapper {
 
   @Mapping(source = "indexInfo.id", target = "id")
   @Mapping(source = "indexInfo.indexName", target = "indexName")
-  @Mapping(source = "indexInfo.classification", target = "indexClassification")
+  @Mapping(source = "indexInfo.indexClassification", target = "indexClassification")
   AutoSyncConfigDto toDto(AutoSyncConfig autoSyncConfig);
 }

--- a/src/main/java/com/sprint/project/findex/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/sprint/project/findex/repository/AutoSyncConfigRepository.java
@@ -1,8 +1,12 @@
 package com.sprint.project.findex.repository;
 
 import com.sprint.project.findex.entity.AutoSyncConfig;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, Integer> {
 
+  @EntityGraph(attributePaths = "indexInfo")
+  List<AutoSyncConfig> findByEnabledTrue();
 }

--- a/src/main/java/com/sprint/project/findex/scheduler/AutoSyncScheduler.java
+++ b/src/main/java/com/sprint/project/findex/scheduler/AutoSyncScheduler.java
@@ -1,5 +1,6 @@
 package com.sprint.project.findex.scheduler;
 
+import com.sprint.project.findex.service.AutoSyncConfigService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,8 +11,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AutoSyncScheduler {
 
-  // Todo: 추후 서비스 계층 구현 완료되면 활성화 될 에정
-  // private final AutoSyncConfigService autoSyncConfigService;
+   private final AutoSyncConfigService autoSyncConfigService;
 
   // application.yml에서 설정한 cron 값을 호출
   @Scheduled(cron = "${findex.scheduler.auto-sync.cron}")
@@ -19,8 +19,7 @@ public class AutoSyncScheduler {
     log.info("[Batch Start] 자동 연동 배치 실행 시작");
 
     try {
-      // Todo: 포함 로직 서비스 호출 코드 작성
-      // autoSyncConfigService.syncEnabledIndices();
+       autoSyncConfigService.syncEnabledIndices();
 
       log.info("[Batch End] 자동 연동 배치 실행 완료");
     } catch (Exception e) {

--- a/src/main/java/com/sprint/project/findex/service/AutoSyncConfigService.java
+++ b/src/main/java/com/sprint/project/findex/service/AutoSyncConfigService.java
@@ -5,12 +5,15 @@ import com.sprint.project.findex.dto.autosyncconfig.AutoSyncConfigUpdateRequest;
 import com.sprint.project.findex.entity.AutoSyncConfig;
 import com.sprint.project.findex.mapper.AutoSyncConfigMapper;
 import com.sprint.project.findex.repository.AutoSyncConfigRepository;
-import com.sprint.project.findex.IndexInfo;
+import com.sprint.project.findex.entity.IndexInfo;
+import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AutoSyncConfigService {
@@ -43,6 +46,28 @@ public class AutoSyncConfigService {
         .orElseThrow(() -> new NoSuchElementException("존재하지 않는 자동 연동 설정입니다. ID: " + id));
   }
 
+  // 스케줄러 로직
+  // Todo: 따로 서비스 클래스를 나눠서 작성할지, 지금처럼 해당 클래스에 명시할지 의논하는게 좋을 것 같습니다.
+  public void syncEnabledIndices() {
+    log.info("[AutoSync] 자동 연동 활성화 지수 조회 시작");
 
+    List<AutoSyncConfig> enabledConfigs =
+        autoSyncConfigRepository.findByEnabledTrue();
 
+    log.info("[AutoSync] 조회된 자동 연동 대상 개수: {}", enabledConfigs.size());
+
+    for (AutoSyncConfig config : enabledConfigs) {
+
+      try {
+        syncIndex(config);
+      } catch (Exception e) {
+        log.error("[AutoSync] 지수 동기화 실패: configId = {}", config.getId(), e);
+      }
+    }
+  }
+
+  private void syncIndex(AutoSyncConfig config) {
+
+    log.info("[AutoSync] 지수 동기화 실행: configId = {}", config.getId());
+  }
 }


### PR DESCRIPTION
--- 본문 ---
- 자동 연동 배치 실행 시 활성화된 지수만 조회하도록 로직 구현
- AutoSyncConfigService에서 조회 로직 구현
- AutoSyncScheduler에서 배치 실행 시 필터링된 지수 대상으로 동기화 수행
- AutoSyncConfig 관련 Entity, Repository, Mapper 일부 수정

--- 꼬리말 ---
close: #11

## 📝 설명

- 자동 연동 배치 실행 시 활성화된 지수만 조회하도록 로직을 구현했습니다.
- AutoSyncConfigService에서 조회 로직을 작성하고, AutoSyncScheduler에서 필터링된 지수를 대상으로 동기화를 수행하도록 구성했습니다.
- 현재 스케줄러 로직을 AutoSyncConfigService 하단에 명시하였습니다.
  - 따로 서비스 클래스를 나눠서 작성할지, 지금처럼 해당 클래스에 명시할지 의논하는게 좋을 것 같습니다.
- AutoSyncConfig 관련 클래스의 코드 일부를 수정하였습니다.
- 하나님께서 작성해주신 테스트 코드(AutoSyncConfigServiceTest)는 기존 그대로 유지하였으며, 별도로 수정하지 않았습니다.

## 🚀 변경 사항

- 없습니다.

## 🔗 짧은 회고

- git 협업에 대해서 배울 수 있었습니다.

close: #11 