### PR TITLE
fix: 자동 연동 스케줄러 로직 구현 및 데이터 동기화 최적화

### DIFF
--- a/src/main/java/com/sprint/project/findex/config/openapi/OpenApiConfig.java
+++ b/src/main/java/com/sprint/project/findex/config/openapi/OpenApiConfig.java
@@ -33,6 +33,7 @@ public class OpenApiConfig {
 
     return WebClient.builder()
         .uriBuilderFactory(factory)
+        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .build();
   }

--- a/src/main/java/com/sprint/project/findex/repository/IndexDataRepository.java
+++ b/src/main/java/com/sprint/project/findex/repository/IndexDataRepository.java
@@ -7,30 +7,14 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
 
 public interface IndexDataRepository extends JpaRepository<IndexData, Long>,
     IndexDataQDSLRepository {
   boolean existsByIndexInfoAndBaseDate(IndexInfo indexInfo, LocalDate baseDate);
 
-
-
   @EntityGraph(attributePaths = "indexInfo")
   Optional<IndexData> findTopByIndexInfoOrderByBaseDateDesc(IndexInfo indexInfo);
-
-  @Query("SELECT i.indexInfo.id AS indexInfoId, MAX(i.baseDate) AS lastDate " +
-      "FROM IndexData i " +
-      "WHERE i.indexInfo IN :indexInfos " +
-      "GROUP BY i.indexInfo.id")
-  List<LastSyncDateProjection> findLastSyncDates(@Param("indexInfos") List<IndexInfo> indexInfos);
-
-  interface LastSyncDateProjection {
-
-    Long getIndexInfoId();
-
-    LocalDate getLastDate();
-  }
 
   List<IndexData> findByIndexInfoAndBaseDateBetween(IndexInfo indexInfo,
       LocalDate fromDate,

--- a/src/main/java/com/sprint/project/findex/repository/SyncJobRepository.java
+++ b/src/main/java/com/sprint/project/findex/repository/SyncJobRepository.java
@@ -1,9 +1,31 @@
 package com.sprint.project.findex.repository;
 
+import com.sprint.project.findex.entity.IndexInfo;
 import com.sprint.project.findex.entity.SyncJob;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SyncJobRepository extends JpaRepository<SyncJob, Long>, SyncJobQDSLRepository {
 
+  @Query("SELECT s.indexInfo.id AS indexInfoId, MAX(s.targetDate) AS lastDate " +
+      "FROM SyncJob s " +
+      "WHERE s.indexInfo IN :indexInfos AND s.result = 'SUCCESS' " +
+      "GROUP BY s.indexInfo.id")
+  List<LastSyncDateProjection> findLastSyncDates(@Param("indexInfos") Set<IndexInfo> indexInfos);
 
+  interface LastSyncDateProjection {
+    Long getIndexInfoId();
+    LocalDate getLastDate();
+  }
+
+  @Query("SELECT s.indexInfo.id AS indexInfoId, MAX(s.targetDate) AS lastDate " +
+      "FROM SyncJob s " +
+      "JOIN AutoSyncConfig asc ON s.indexInfo = asc.indexInfo " +
+      "WHERE asc.enabled = true AND s.result = 'SUCCESS' " +
+      "GROUP BY s.indexInfo.id")
+  List<LastSyncDateProjection> findLastSyncDatesEnabledOnly();
 }

--- a/src/main/java/com/sprint/project/findex/service/openapi/OpenApiService.java
+++ b/src/main/java/com/sprint/project/findex/service/openapi/OpenApiService.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -59,7 +58,7 @@ public class OpenApiService {
       LocalDate endDate = LocalDate.now();
 
       int pageNo = 1;
-      int numOfRows = 500;
+      int numOfRows = 1000;
       List<StockIndexDto> buffer = new ArrayList<>();
 
       while (true) {

--- a/src/main/java/com/sprint/project/findex/service/openapi/internal/PersistentWorker.java
+++ b/src/main/java/com/sprint/project/findex/service/openapi/internal/PersistentWorker.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -128,21 +129,22 @@ public class PersistentWorker {
   }
 
   public Map<Long, LocalDate> findLastSyncDatesBulk(List<AutoSyncConfig> configs) {
-    List<IndexInfo> indexInfos = configs.stream()
-        .map(AutoSyncConfig::getIndexInfo)
-        .toList();
+    if (configs.isEmpty()) return new HashMap<>();
 
-    List<IndexDataRepository.LastSyncDateProjection> results = indexDataRepository.findLastSyncDates(indexInfos);
+    // 파라미터를 넘기는 대신, 쿼리 내부에서 JOIN으로 처리하는 메서드 호출
+    List<SyncJobRepository.LastSyncDateProjection> results =
+        syncJobRepository.findLastSyncDatesEnabledOnly();
 
     Map<Long, LocalDate> lastSyncMap = results.stream()
         .collect(Collectors.toMap(
-            IndexDataRepository.LastSyncDateProjection::getIndexInfoId,
-            IndexDataRepository.LastSyncDateProjection::getLastDate
+            SyncJobRepository.LastSyncDateProjection::getIndexInfoId,
+            SyncJobRepository.LastSyncDateProjection::getLastDate
         ));
 
+    // 데이터가 없는 경우 기본값(시작 시점) 채워넣기
     for (AutoSyncConfig config : configs) {
       lastSyncMap.putIfAbsent(config.getIndexInfo().getId(),
-          config.getIndexInfo().getCreatedAt().atZone(ZoneId.systemDefault()).toLocalDate());
+          config.getIndexInfo().getBasePointInTime());
     }
 
     return lastSyncMap;


### PR DESCRIPTION
--- 본문 ---

- 데이터 소스 신뢰성 개선: 기존 IndexData 기준의 마지막 동기화 일자 조회 방식을 SyncJob(성공 이력) 기준으로 변경하여 정확한 데이터 추적 가능
- 활성화 지수 필터링: auto_sync_configs의 enabled 상태를 기반으로 연동 대상을 필터링하는 로직 구현
- 동기화 기간 최적화: 마지막 성공 시점 다음 날부터 오늘까지의 데이터만 요청하여 중복 호출 및 부하 감소
- 메모리 및 성능 최적화:
  - 대용량 응답 처리를 위한 WebClient 인메모리 버퍼 크기 확장 (10MB)
- 예외 처리 강화: 동기화 이력이 없는 신규 지수 처리(basePointInTime 기준) 및 배치 실행 로그 모니터링 강화

## 📝 설명

1. 조회 기준 변경 (IndexData → SyncJob)
   - 대상 날짜를 조회하는 메서드를 Index쪽이 아니라 SyncJob에서 처리해야 하는데 이 부분을 수정했습니다. 

2. 연동 필터링
   - `auto_sync_configs`의 `enabled` 상태를 조인하여 활성화된 지수만 선별적으로 수집합니다.

3. 배치 처리 (Buffer)
   - 많은 데이터를 한 번에 불러올 때 간혹 발생하는 버퍼 용량 초과 오류(DataBufferLimitException)를 방지하고, 대용량 데이터를 끊김 없이 안정적으로 처리하기 위해 메모리 제한을 10MB로 늘렸습니다.

## 🚀 변경 사항

- 생각보다 많이 길어져서 죄송할 따름입니다 ..

## 🔗 짧은 회고

- 배치 스케줄러와 OPENAPI 연동에 대해서 알게 되었습니다.